### PR TITLE
Use escape_url instead of escape_slash for standard parts as well.

### DIFF
--- a/onshape_to_robot/onshape_api/client.py
+++ b/onshape_to_robot/onshape_api/client.py
@@ -356,6 +356,6 @@ class Client():
     
     def standard_cont_mass_properties(self, did, vid, eid, partid, linkDocumentId, configuration):
         def invoke():
-            return self._api.request('get', '/api/parts/d/' + did + '/v/' + vid + '/e/' + eid + '/partid/'+escape_slash(partid)+'/massproperties', query={'configuration': configuration, 'useMassPropertyOverrides': True, "linkDocumentId": linkDocumentId, "inferMetadataOwner": True})
+            return self._api.request('get', '/api/parts/d/' + did + '/v/' + vid + '/e/' + eid + '/partid/'+escape_url(partid)+'/massproperties', query={'configuration': configuration, 'useMassPropertyOverrides': True, "linkDocumentId": linkDocumentId, "inferMetadataOwner": True})
 
         return json.loads(self.cache_get('standard_massproperties', (did, vid, eid, self.hash_partid(partid), configuration), invoke, True))


### PR DESCRIPTION
This seems to be the default for the other file types and fixed an issue for me